### PR TITLE
feat: make browser friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const crypto = require('crypto')
+const randomBytes = require('random-bytes')
 const Readable = require('stream').Readable
 
 const defaultOptions = {
   chunkSize: 4096,
-  generator: (size, callback) => {
-    callback(null, crypto.randomBytes(size))
-  }
+  generator: randomBytes
 }
 
 class BufferStream extends Readable {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const randomBytes = require('random-bytes')
+const randomBytes = require('randombytes')
 const Readable = require('stream').Readable
 
 const defaultOptions = {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "A readable stream that emits buffers containing bytes up to a certain length",
   "main": "index.js",
+  "browser": {
+    "stream": "readable-stream"
+  },
   "scripts": {
     "test": "nyc --check-coverage --lines 100 --reporter html --reporter lcov ava",
     "lint": "standard",
@@ -23,5 +26,9 @@
     "coveralls": "^3.0.2",
     "nyc": "^14.0.0",
     "standard": "^12.0.1"
+  },
+  "dependencies": {
+    "random-bytes": "^1.0.0",
+    "readable-stream": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "standard": "^12.0.1"
   },
   "dependencies": {
-    "random-bytes": "^1.0.0",
+    "randombytes": "^2.1.0",
     "readable-stream": "^3.5.0"
   }
 }


### PR DESCRIPTION
In the browser:

1. Use the browser crypto API, do not bundle Node.js "crypto"!
1. Do not assume bundler bundles the "stream" module automatically, import the `readable-stream` module